### PR TITLE
Add Teams supervisor keepalive CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,19 @@ jobs:
           teams_runtime_keepalive='Test(TeamsBackgroundKeepalive|Bridge(LongRunningTurnKeepsOwnerHeartbeatActive|IdleOwnerHeartbeatPreservesActiveTurnFields|ListenStandbyDoesNotCreateControlChatOrPoll)|ClaimControlLease(PrimaryBeatsEphemeralAndEphemeralStaysStandby|DoesNotPreemptActiveTurn|ConcurrentManyMachinesSingleActive)|ControlLeaseForwardJumpAllowsTakeoverAfterSleep|IsStaleHandlesFutureHeartbeatAndThresholdBoundary|ValidateAndReleaseControlLease|RecordOwnerHeartbeat(WritesAndReadsOwner|UpdatesExistingOwner|RefusesLiveOwnerWithDiagnostic)|RecoverStaleOwner(ReplacesStaleOwner|RefusesLiveOwner)|ClearOwner(IsIdempotent|IfSameDoesNotClearDifferentOwner)|Graph(DoesNotRetryPostServerErrors|RetriesPostTooManyRequestsAfterRetryAfter))'
           go test -race ./internal/teams ./internal/teams/store -count=1 -run "$teams_runtime_keepalive" -v
 
+      - name: Teams supervisor smoke (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/teams_supervisor_smoke.sh
+
+      - name: Teams supervisor smoke (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          .\scripts\ci\teams_supervisor_smoke.ps1
+
       - name: Self-update env pollution regressions (Linux/macOS)
         if: runner.os != 'Windows'
         shell: bash
@@ -667,6 +680,12 @@ jobs:
               -e CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE=/tmp/codex-cache/teams-missing-file-token.json \
               -v "$PWD/dist:/dist:ro" "$img" \
               /dist/codex_teams_store_test -test.v -test.count=1 -test.run='TestTeamsBackgroundKeepalive'
+            echo "==> $img (Teams detached supervisor smoke as non-root uid 1000)"
+            docker run --rm --user 1000:1000 \
+              -e HOME=/tmp/codex-home \
+              -e RUNNER_TEMP=/tmp/codex-runner-temp \
+              -v "$PWD/scripts/ci:/ci:ro" "$img" \
+              bash /ci/teams_supervisor_smoke.sh
           done
 
       - name: Codex upgrade smoke in Linux containers (system/local)

--- a/internal/cli/teams_service.go
+++ b/internal/cli/teams_service.go
@@ -269,6 +269,9 @@ func newTeamsServiceDoctorCmd() *cobra.Command {
 				} else {
 					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "WSL: detected. systemd --user requires WSL systemd and a running user manager; for Windows-login autostart, unset CODEX_HELPER_TEAMS_WSL_SERVICE_BACKEND=systemd.")
 				}
+			} else if teamsServiceGOOS() == "linux" && backend.ID() == "systemd-user" {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Linux: systemd --user keeps the Teams bridge independent of the terminal while the user manager is alive.")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Linux: if lingering is disabled, a full logout may stop the user manager; without root/admin policy changes, no user service can guarantee survival after that boundary.")
 			}
 			return nil
 		},

--- a/internal/cli/teams_service_test.go
+++ b/internal/cli/teams_service_test.go
@@ -232,6 +232,9 @@ func TestTeamsServiceDoctorReportsAuthAndExecutableWithoutFailingFast(t *testing
 		"temporary go run binary",
 		"Teams service auth: not ready",
 		"auth missing",
+		"Linux: systemd --user keeps the Teams bridge independent of the terminal",
+		"if lingering is disabled",
+		"no user service can guarantee survival",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, got)

--- a/internal/teams/graph_test.go
+++ b/internal/teams/graph_test.go
@@ -3,6 +3,7 @@ package teams
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -106,6 +107,84 @@ func TestGraphRetriesTooManyRequestsAfterRetryAfter(t *testing.T) {
 	}
 	if len(sleeps) != 1 || sleeps[0] != 2*time.Second {
 		t.Fatalf("unexpected sleeps: %v", sleeps)
+	}
+}
+
+func TestTeamsBackgroundKeepaliveGraphNetworkDisconnectThenNextCallRecoversCI(t *testing.T) {
+	auth := &fakeGraphAuth{token: "access"}
+	var attempts int
+	graph := &GraphClient{
+		auth: auth,
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, fmt.Errorf("simulated network disconnect")
+			}
+			if got := req.URL.String(); got != "https://graph.example.test/me?$select=id,displayName,userPrincipalName" {
+				t.Fatalf("unexpected request URL: %s", got)
+			}
+			return jsonResponse(http.StatusOK, `{"id":"u1","displayName":"User One","userPrincipalName":"u1@example.test"}`), nil
+		})},
+		baseURL:    "https://graph.example.test",
+		maxRetries: 3,
+		backoffMin: time.Millisecond,
+		backoffMax: time.Millisecond,
+		sleep:      func(context.Context, time.Duration) error { return nil },
+		jitter:     func(d time.Duration) time.Duration { return d },
+	}
+
+	if _, err := graph.Me(context.Background()); err == nil || !strings.Contains(err.Error(), "simulated network disconnect") {
+		t.Fatalf("first Graph call error = %v, want simulated network disconnect", err)
+	}
+	user, err := graph.Me(context.Background())
+	if err != nil {
+		t.Fatalf("second Graph call should recover after transport error: %v", err)
+	}
+	if attempts != 2 || user.ID != "u1" {
+		t.Fatalf("attempts=%d user=%#v, want second call recovery", attempts, user)
+	}
+}
+
+func TestTeamsBackgroundKeepaliveGraphLongRetryAfterIsInterruptibleCI(t *testing.T) {
+	auth := &fakeGraphAuth{token: "access"}
+	var sleeps []time.Duration
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Retry-After", "3600")
+		http.Error(w, `{"error":{"code":"TooManyRequests","message":"long throttle"}}`, http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	graph := newTestGraphClient(auth, server, &sleeps)
+	graph.sleep = func(ctx context.Context, delay time.Duration) error {
+		sleeps = append(sleeps, delay)
+		return context.Canceled
+	}
+	_, err := graph.Me(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Graph long Retry-After error = %v, want context.Canceled", err)
+	}
+	if len(sleeps) != 1 || sleeps[0] != time.Hour {
+		t.Fatalf("Graph long Retry-After sleeps = %v, want 1h", sleeps)
+	}
+}
+
+func TestTeamsBackgroundKeepaliveGraphServerDelayRespectsContextDeadlineCI(t *testing.T) {
+	auth := &fakeGraphAuth{token: "access"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+
+	graph := newTestGraphClient(auth, server, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err := graph.Me(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Graph delayed server error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("Graph delayed server did not respect context promptly: %v", elapsed)
 	}
 }
 

--- a/scripts/ci/teams_supervisor_smoke.ps1
+++ b/scripts/ci/teams_supervisor_smoke.ps1
@@ -1,0 +1,75 @@
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+$root = Join-Path $env:RUNNER_TEMP ("codex-helper-teams-supervisor-smoke-" + $PID)
+New-Item -ItemType Directory -Force -Path $root | Out-Null
+$taskName = "Codex Helper Teams CI Smoke $PID"
+$heartbeat = Join-Path $root "scheduled-task-heartbeat.log"
+$body = Join-Path $root "scheduled-task-body.ps1"
+
+function Log($message) {
+  Write-Host "[teams-supervisor-smoke] $message"
+}
+
+function Wait-HeartbeatLines($path, $minLines) {
+  $deadline = (Get-Date).AddSeconds(45)
+  while ((Get-Date) -lt $deadline) {
+    if (Test-Path $path) {
+      $count = (Get-Content -Path $path -ErrorAction SilentlyContinue | Measure-Object -Line).Lines
+      if ($count -ge $minLines) {
+        return
+      }
+    }
+    Start-Sleep -Seconds 1
+  }
+  if (Test-Path $path) {
+    Get-Content $path | ForEach-Object { Write-Host "[heartbeat] $_" }
+  }
+  throw "Timed out waiting for $path to reach $minLines lines"
+}
+
+try {
+  Log "Windows Scheduled Task smoke: register a per-user task and start it manually"
+  @"
+`$heartbeat = '$heartbeat'
+`$end = (Get-Date).AddSeconds(20)
+while ((Get-Date) -lt `$end) {
+  Add-Content -Path `$heartbeat -Value ("{0:o} pid={1}" -f (Get-Date), `$PID)
+  Start-Sleep -Seconds 1
+}
+"@ | Set-Content -Path $body -Encoding UTF8
+
+  $pwsh = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+  if (-not $pwsh) {
+    $pwsh = (Get-Command powershell.exe -ErrorAction Stop).Source
+  }
+  $action = New-ScheduledTaskAction -Execute $pwsh -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$body`""
+  $trigger = New-ScheduledTaskTrigger -AtLogOn
+  $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+  $userId = if ($env:USERDOMAIN) { "$env:USERDOMAIN\$env:USERNAME" } else { $env:USERNAME }
+  $principal = New-ScheduledTaskPrincipal -UserId $userId -LogonType Interactive -RunLevel Limited
+  Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Force | Out-Null
+  Start-ScheduledTask -TaskName $taskName
+  Wait-HeartbeatLines $heartbeat 2
+
+  $task = Get-ScheduledTask -TaskName $taskName
+  if ($task.State -eq "Disabled") {
+    throw "Scheduled task was unexpectedly disabled"
+  }
+
+  if (Get-Command wsl.exe -ErrorAction SilentlyContinue) {
+    Log "wsl.exe exists; checking whether a distro is available for WSL task smoke"
+    $distros = @(wsl.exe -l -q 2>$null | Where-Object { $_ -and $_.Trim() })
+    if ($distros.Count -gt 0) {
+      wsl.exe -d $distros[0] -e sh -lc "printf wsl-ok"
+    } else {
+      Write-Warning "wsl.exe exists but no distro is installed on this runner; WSL launch is covered by command-generation tests"
+    }
+  } else {
+    Write-Warning "wsl.exe is not available on this runner; WSL launch is covered by command-generation tests"
+  }
+} finally {
+  Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue | Out-Null
+  Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue | Out-Null
+  Remove-Item -Recurse -Force $root -ErrorAction SilentlyContinue
+}

--- a/scripts/ci/teams_supervisor_smoke.sh
+++ b/scripts/ci/teams_supervisor_smoke.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/codex-helper-teams-supervisor-smoke-$$"
+mkdir -p "$root"
+
+log() {
+  printf '[teams-supervisor-smoke] %s\n' "$*"
+}
+
+cleanup_pids=()
+cleanup_launchd_label=""
+cleanup_systemd_unit=""
+
+cleanup() {
+  for pid in "${cleanup_pids[@]:-}"; do
+    kill "$pid" >/dev/null 2>&1 || true
+  done
+  if [ -n "$cleanup_launchd_label" ] && [ "$(uname -s)" = "Darwin" ]; then
+    launchctl bootout "gui/$(id -u)/$cleanup_launchd_label" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$cleanup_systemd_unit" ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl --user stop "$cleanup_systemd_unit" >/dev/null 2>&1 || true
+    systemctl --user disable "$cleanup_systemd_unit" >/dev/null 2>&1 || true
+    rm -f "$HOME/.config/systemd/user/$cleanup_systemd_unit"
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+  fi
+  rm -rf "$root"
+}
+trap cleanup EXIT
+
+wait_for_lines() {
+  local file="$1"
+  local min_lines="$2"
+  local deadline=$((SECONDS + 30))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if [ -f "$file" ]; then
+      local lines
+      lines="$(wc -l <"$file" | tr -d ' ')"
+      if [ "${lines:-0}" -ge "$min_lines" ]; then
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  log "timed out waiting for $file to reach $min_lines lines"
+  [ -f "$file" ] && sed 's/^/[heartbeat] /' "$file" || true
+  return 1
+}
+
+write_probe_loop() {
+  local path="$1"
+  cat >"$path" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+heartbeat="$1"
+trap '' HUP
+while :; do
+  printf '%s pid=%s\n' "$(date +%s)" "$$" >>"$heartbeat"
+  sleep 1
+done
+EOS
+  chmod +x "$path"
+}
+
+terminal_detach_smoke() {
+  log "terminal detach smoke: child should survive parent shell exit and SIGHUP"
+  local probe="$root/probe-loop.sh"
+  local heartbeat="$root/terminal-heartbeat.log"
+  local pidfile="$root/terminal.pid"
+  write_probe_loop "$probe"
+  (
+    "$probe" "$heartbeat" >/dev/null 2>&1 &
+    echo "$!" >"$pidfile"
+  )
+  local pid
+  pid="$(cat "$pidfile")"
+  cleanup_pids+=("$pid")
+  wait_for_lines "$heartbeat" 2
+  kill -HUP "$pid" >/dev/null 2>&1 || true
+  wait_for_lines "$heartbeat" 4
+  if ! kill -0 "$pid" >/dev/null 2>&1; then
+    log "detached child died after parent/SIGHUP simulation"
+    return 1
+  fi
+}
+
+linux_systemd_user_smoke() {
+  [ "$(uname -s)" = "Linux" ] || return 0
+  log "linux systemd --user smoke: test real user supervisor when available"
+  if ! command -v systemctl >/dev/null 2>&1; then
+    log "::warning::systemctl is not available; hosted CI cannot exercise systemd --user here"
+    return 0
+  fi
+  if ! systemctl --user show-environment >/dev/null 2>&1; then
+    log "::warning::systemd --user is not available in this runner session; this is the no-user-manager/no-linger boundary"
+    if command -v loginctl >/dev/null 2>&1; then
+      user_name="$(id -un 2>/dev/null || id -u)"
+      loginctl show-user "$user_name" -p Linger -p State 2>/dev/null || true
+    fi
+    return 0
+  fi
+
+  local unit="codex-helper-teams-ci-smoke-$RANDOM.service"
+  local heartbeat="$root/systemd-heartbeat.log"
+  local unitdir="$HOME/.config/systemd/user"
+  mkdir -p "$unitdir"
+  cleanup_systemd_unit="$unit"
+  cat >"$unitdir/$unit" <<EOF
+[Unit]
+Description=Codex Helper Teams CI user-service smoke
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c 'while :; do date +%%s >> "$heartbeat"; sleep 1; done'
+Restart=on-failure
+RestartSec=1s
+
+[Install]
+WantedBy=default.target
+EOF
+  systemctl --user daemon-reload
+  systemctl --user start "$unit"
+  wait_for_lines "$heartbeat" 2
+  local pid
+  pid="$(systemctl --user show "$unit" -p MainPID --value 2>/dev/null || true)"
+  if [ -n "$pid" ] && [ "$pid" != "0" ]; then
+    local before
+    before="$(wc -l <"$heartbeat" | tr -d ' ')"
+    kill -KILL "$pid" >/dev/null 2>&1 || true
+    wait_for_lines "$heartbeat" "$((before + 2))"
+  fi
+}
+
+macos_launchagent_smoke() {
+  [ "$(uname -s)" = "Darwin" ] || return 0
+  log "macOS LaunchAgent smoke: bootstrap, heartbeat, and restart after process kill"
+  local label="com.codex-helper.teams-ci-smoke.$RANDOM.$$"
+  local plist="$root/$label.plist"
+  local heartbeat="$root/launchagent-heartbeat.log"
+  cleanup_launchd_label="$label"
+  cat >"$plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$label</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>while :; do date +%s &gt;&gt; "$heartbeat"; sleep 1; done</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>$root/launchagent.out</string>
+  <key>StandardErrorPath</key>
+  <string>$root/launchagent.err</string>
+</dict>
+</plist>
+EOF
+  plutil -lint "$plist"
+  launchctl bootstrap "gui/$(id -u)" "$plist"
+  wait_for_lines "$heartbeat" 2
+  local pid
+  pid="$(launchctl print "gui/$(id -u)/$label" 2>/dev/null | awk -F'= ' '/pid =/{print $2; exit}' || true)"
+  if [ -n "$pid" ]; then
+    kill "$pid" >/dev/null 2>&1 || true
+    wait_for_lines "$heartbeat" 4
+  fi
+}
+
+terminal_detach_smoke
+linux_systemd_user_smoke
+macos_launchagent_smoke


### PR DESCRIPTION
## Summary
- Add GitHub CI supervisor smoke tests for terminal-detach behavior, macOS LaunchAgent, Windows Scheduled Task, and non-root Linux container detach behavior.
- Add deterministic Graph fault tests for network disconnect recovery, long Retry-After cancellation, and delayed server responses.
- Make Linux Teams service doctor explicitly call out the no-linger/user-manager boundary.

## Validation
- go test ./... -count=1
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -color
- bash scripts/ci/teams_supervisor_smoke.sh
- non-root container supervisor smoke on centos:7, rockylinux:8, ubuntu:20.04
- high-confidence secret scan over branch commits