### PR TITLE
Add Teams CI coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
           set -euo pipefail
           bridge_pattern='Test(BridgeAsync(QueuedTurnsRunAcrossSessionsButSerializeEachSession|TurnsQueuesTeamsInputWhileCodexIsRunning|TurnsSendsQueuedNoticeForEveryNewBacklogMessage)|BridgeWarnsWhenCodexIdleMayBeStuck|BridgeQueuesTeamsPromptWhileExternalCodexTranscriptActive|BridgeSessionCancel(LastRunningTurnCancelsExecutor|RunningTurnWithoutLiveHandleExplainsLimit)|LatestCancelableTurnIDPrefersRunningOverQueued|BridgePollOnce(BoostsAfterRealInboundAndFinalOutput|PrioritizesRunningWorkChatUnderPerCycleLimit|ContinuesOtherDueChatsAfterReadRateLimit|ParksIdleWorkChatAndSendsFreezeNotice|DoesNotRepeatFreezeNoticeFrom(SentOutbox|GraphHistory)|SendsNewFreezeNoticeAfterEarlierResume|IgnoresStaleControlFallbackRegistryProjection)|BridgeWorkPublishHistoryImportsBlockedBacklogAndRunsQueuedTurn|BridgeBlocksQueuedTurnOnLocalToolOnlyTranscriptActivity|BridgeControlResume(ClearsStaleContinuationBeforePolling|KeyOnlyReactivatesMatchingParkedChat|KeyReactivatesParkedWorkChat)|BridgeControlPollIgnoresHistoricalHelperOutputAndClearsContinuation|BridgeSyncLinkedTranscript(DedupesQueuedLiveFinal|ResumesInterruptedImportAfterOwnerRestart|RetriesRemainingRecordsFromSameLine)|BridgeHistoryWatch.*|LinkedCheckpointFileUnchangedRequiresFullyProcessedOffset|ChatPollScheduleCanClearContinuationPath|StoreConcurrentDistinctSessionWritersDoNotCrossMutate|InboundPollDecision(Thresholds|FutureActivityStaysHot|IgnoresControlContinuation)|SortInboundPollDecisionsPrioritizesRunningUnderCycleCap)$'
           transcript_pattern='Test(ReadSessionTranscriptSince(RefusesMissingCheckpoint|MatchesFullTailForSourceCheckpoint|MatchesFullTailForFallbackCheckpoint|RefusesInvalidLineLikeCheckpoint|FallsBackForPrefixDuplicateSourceIDs|AvoidsFullParseWorkForTail)|HistoryTiered(StatDetectsOnlyChangedFiles|ListSessionFilesInDirs|ScanTail(WaitsForCompletedTurn|MethodTurnCompletedWithItems|MultipleFinalAnswersInOneTail|UsesLastAssistantBeforeTerminal|DoesNotCompleteDifferentTurn|TreatsFinalAnswerPhaseAsComplete|FallbackIDsMatchFullParserWithSessionID|DoesNotTreatFinalAnswerTextAsPhase|DoesNotConsumeIncompleteTrailingLine|CapsLargeTail|CanRecoverAfterLargeTailCap|TruncateDoesNotSkipRewrittenContent)))$'
-          render_artifact_pattern='Test(DefaultTeamsChunkLimitsAreClientConservative|RenderTeamsHTMLCodexMarkdownRulesAndBlockquotesUseStructuralHTML|ParseArtifactManifestAllowsZipArtifacts|PrepareOutboundAttachmentAllowsZip|BridgePollAllowsOwnerMessageStartingWithHelperPrefix)$'
+          render_artifact_pattern='Test(DefaultTeamsChunkLimitsAreClientConservative|RenderTeamsHTMLCodexMarkdownRulesAndBlockquotesUseStructuralHTML|ParseArtifactManifestAllowsZipArtifacts|PrepareOutboundAttachmentAllowsZip|BridgePollAllowsOwnerMessageStartingWithHelperPrefix|P1ArtifactManifest(WithoutFileWriteAuthLeavesFinalVisibleAndWarns|RejectedAfterFinalWhenAuthExists)|BridgeAttachment(SendFailureRestartReusesUploadedDriveItem|ReplayRejectsTamperedStagedFileBeforeUpload)|SimulatedLive(TeamsRenderCasesRoundTripThroughGraphCI|HelperE2EControlWorkAndStatusCI))$'
           workflow_pattern='Test(WorkflowNotificationsDisabledByDefault|WorkflowNotification(SendsAfterDurableOutboxSent|SendsDetectedCodexAnswerOnce|SendsManualHelperUpgradeCard|SkipsPlainAutoHelperUpgradeNotice|FallsBackToSidecarConfigWhenOldHelperErasesState|DoesNotDuplicateAfterAmbiguousFailure|ConcurrentFlushClaimsOnce|StaleSendingBecomesUnknown|RetriesOnlyRetryableFailuresWithBackoff|SuppressesAfterControlChatRebind|SkipsHistoricalImportsAndNotifiesDetectedSyncFinals|SupportsRecreatedChatMovedNotice)|QueueOutbox(SuppressesOwnerMentionWhenWorkflowNotificationEnabled|KeepsOwnerMentionWhenWorkflowNotificationDisabled)|WorkflowWebhookURLFileSafety|ConfigureWorkflowNotificationsFromWebhookURLWritesPrivateSecret|BridgeControlWebhook(CommandConfiguresWorkflowWithoutRunningCodex|RejectsInvalidURLWithoutRunningCodex)|PostWorkflowWebhook(SendsAdaptiveCard|RejectsUnsafeActionURL|RejectsNonAbsoluteWebhookURL|RejectsOversizedPayload|RetriesTooManyRequests|ClassifiesServerErrorAsDeliveryUncertain|ClassifiesTransportErrorAsDeliveryUncertain|ClassifiesInterruptedRateLimitWaitAsRetryable))$'
           workflow_cli_pattern='TestTeamsWorkflowStatus(RedactsWebhookURL|ReadsSidecarConfig)$'
           go test ./internal/teams ./internal/teams/store -count=1 -run "$bridge_pattern" -v
@@ -386,6 +386,19 @@ jobs:
         shell: pwsh
         run: |
           .\scripts\ci\teams_supervisor_smoke.ps1
+
+      - name: Teams installed binary local smoke (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/teams_installed_smoke.sh
+
+      - name: Teams installed binary local smoke (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          .\scripts\ci\teams_installed_smoke.ps1
 
       - name: Self-update env pollution regressions (Linux/macOS)
         if: runner.os != 'Windows'
@@ -461,6 +474,45 @@ jobs:
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
           & .\scripts\ci\retry.ps1 5 5 npm install -g --include=optional '@openai/codex'
+
+      - name: Teams app-server probe (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v codex >/dev/null 2>&1; then
+            echo "Codex not available, skipping Teams app-server probe"
+            exit 0
+          fi
+          if ! codex app-server --help >/dev/null 2>&1; then
+            echo "Codex app-server is unavailable, skipping Teams app-server probe"
+            exit 0
+          fi
+          go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path "$(command -v codex)" --workdir "$RUNNER_TEMP" --probe-timeout 20s --appserver-probe-runs 2
+
+      - name: Teams app-server probe (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          $codexCommand = Get-Command codex -ErrorAction SilentlyContinue
+          if (-not $codexCommand) {
+            Write-Host "Codex not available, skipping Teams app-server probe"
+            exit 0
+          }
+          $appServerAvailable = $false
+          try {
+            & codex app-server --help *> $null
+            $appServerAvailable = ($LASTEXITCODE -eq 0)
+          } catch {
+            $appServerAvailable = $false
+          }
+          if (-not $appServerAvailable) {
+            Write-Host "Codex app-server is unavailable, skipping Teams app-server probe"
+            exit 0
+          }
+          go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path $codexCommand.Source --workdir $env:RUNNER_TEMP --probe-timeout 20s --appserver-probe-runs 2
 
       - name: Codex upgrade integration (system npm, Linux/macOS)
         if: runner.os != 'Windows'
@@ -753,6 +805,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          teams_resource_pattern='Test(BridgePollDropsHelperAttachmentEchoWithoutDurableMatch|IsHelperAttachmentEchoMessageVariants|BridgePollOnceDoesNotRewriteStateForUnchangedNotDuePolls|InboundPollDecisionAlreadyPersistedRequiresBlockedStateToMatch|P1ArtifactManifest(WithoutFileWriteAuthLeavesFinalVisibleAndWarns|RejectedAfterFinalWhenAuthExists)|BridgeAttachment(SendFailureRestartReusesUploadedDriveItem|ReplayRejectsTamperedStagedFileBeforeUpload)|HistoryTieredScanTailDoesNotConsumeIncompleteTrailingLine|SimulatedLive(TeamsRenderCasesRoundTripThroughGraphCI|HelperE2EControlWorkAndStatusCI))$'
           img="$DISTRO_IMAGE"
           echo "==> $img (cloudgate tests)"
           docker run --rm -v "$PWD/dist:/dist:ro" "$img" \
@@ -763,9 +816,9 @@ jobs:
           echo "==> $img (proc zombie/parser tests)"
           docker run --rm -v "$PWD/dist:/dist:ro" "$img" \
             /dist/codex_proc_test -test.v -test.count=1 -test.run='Test(IsAliveTreatsLinuxZombieAsDead|LinuxProcStateFromStatParsesLastParen)$'
-          echo "==> $img (Teams resource cleanup tests)"
+          echo "==> $img (Teams resource cleanup, artifact, transcript, and simulated-live tests)"
           docker run --rm -v "$PWD/dist:/dist:ro" "$img" \
-            /dist/codex_teams_test -test.v -test.count=1 -test.run='Test(BridgePollDropsHelperAttachmentEchoWithoutDurableMatch|IsHelperAttachmentEchoMessageVariants|BridgePollOnceDoesNotRewriteStateForUnchangedNotDuePolls|InboundPollDecisionAlreadyPersistedRequiresBlockedStateToMatch)$'
+            /dist/codex_teams_test -test.v -test.count=1 -test.run="$teams_resource_pattern"
           docker run --rm -v "$PWD/dist:/dist:ro" "$img" \
             /dist/codex_teams_store_test -test.v -test.count=1 -test.run='TestChatPollSchedule(NoopDoesNotRewriteState|BlockedNoopPreservesPreviousState|ParkedNoopPreservesParkedAt)$'
 
@@ -774,6 +827,7 @@ jobs:
         run: |
           set -euo pipefail
           teams_runtime_keepalive='Test(TeamsBackgroundKeepalive|TeamsStartupFallback|InboundPoll|Bridge(LongRunningTurnKeepsOwnerHeartbeatActive|IdleOwnerHeartbeatPreservesActiveTurnFields|ListenStandbyDoesNotCreateControlChatOrPoll)|ClaimControlLease(PrimaryBeatsEphemeralAndEphemeralStaysStandby|DoesNotPreemptActiveTurn|ConcurrentManyMachinesSingleActive)|ControlLeaseForwardJumpAllowsTakeoverAfterSleep|IsStaleHandlesFutureHeartbeatAndThresholdBoundary|ValidateAndReleaseControlLease|RecordOwnerHeartbeat(WritesAndReadsOwner|UpdatesExistingOwner|TreatsExecRestartAsSameOwner|RefusesLiveOwnerWithDiagnostic|ReplacesDeadLocalOwnerBeforeStale)|RecoverStaleOwner(ReplacesStaleOwner|TreatsExecRestartAsSameOwner|ReplacesDeadLocalOwnerBeforeStale|RefusesLiveOwner)|ClearOwner(IsIdempotent|IfSameDoesNotClearDifferentOwner|IfSameDoesNotClearSameProcessDifferentInstance)|Graph(DoesNotRetryPostServerErrors|RetriesPostTooManyRequestsAfterRetryAfter))'
+          teams_nonroot_artifact='Test(P1ArtifactManifest(WithoutFileWriteAuthLeavesFinalVisibleAndWarns|RejectedAfterFinalWhenAuthExists)|BridgeAttachment(SendFailureRestartReusesUploadedDriveItem|ReplayRejectsTamperedStagedFileBeforeUpload)|HistoryTieredScanTailDoesNotConsumeIncompleteTrailingLine|SimulatedLive(TeamsRenderCasesRoundTripThroughGraphCI|HelperE2EControlWorkAndStatusCI))$'
           img="$DISTRO_IMAGE"
           echo "==> $img (Teams keepalive tests as non-root uid 1000)"
           docker run --rm --user 1000:1000 \
@@ -803,6 +857,16 @@ jobs:
             -e CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE=/tmp/codex-cache/teams-missing-file-token.json \
             -v "$PWD/dist:/dist:ro" "$img" \
             /dist/codex_teams_store_test -test.v -test.count=1 -test.run="$teams_runtime_keepalive"
+          echo "==> $img (Teams artifact/transcript/simulated-live tests as non-root uid 1000)"
+          docker run --rm --user 1000:1000 \
+            -e HOME=/tmp/codex-home \
+            -e XDG_CONFIG_HOME=/tmp/codex-config \
+            -e XDG_CACHE_HOME=/tmp/codex-cache \
+            -e CODEX_HELPER_TEAMS_TOKEN_CACHE=/tmp/codex-cache/teams-missing-token.json \
+            -e CODEX_HELPER_TEAMS_READ_TOKEN_CACHE=/tmp/codex-cache/teams-missing-read-token.json \
+            -e CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE=/tmp/codex-cache/teams-missing-file-token.json \
+            -v "$PWD/dist:/dist:ro" "$img" \
+            /dist/codex_teams_test -test.v -test.count=1 -test.run="$teams_nonroot_artifact"
           echo "==> $img (Teams detached supervisor smoke as non-root uid 1000)"
           docker run --rm --user 1000:1000 \
             -e HOME=/tmp/codex-home \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,6 +488,16 @@ jobs:
             echo "Codex app-server is unavailable, skipping Teams app-server probe"
             exit 0
           fi
+          export CODEX_HELPER_TEAMS_PROFILE=ci-appserver-probe
+          export CODEX_HELPER_TEAMS_TENANT_ID=ci-tenant
+          export CODEX_HELPER_TEAMS_CLIENT_ID=ci-client
+          export CODEX_HELPER_TEAMS_READ_CLIENT_ID=ci-read-client
+          export CODEX_HELPER_TEAMS_FULL_CLIENT_ID=ci-full-client
+          export CODEX_HELPER_TEAMS_FILE_WRITE_CLIENT_ID=ci-file-client
+          export CODEX_HELPER_TEAMS_TOKEN_CACHE="$RUNNER_TEMP/teams-appserver-token.json"
+          export CODEX_HELPER_TEAMS_READ_TOKEN_CACHE="$RUNNER_TEMP/teams-appserver-read-token.json"
+          export CODEX_HELPER_TEAMS_FULL_TOKEN_CACHE="$RUNNER_TEMP/teams-appserver-full-token.json"
+          export CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE="$RUNNER_TEMP/teams-appserver-file-token.json"
           go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path "$(command -v codex)" --workdir "$RUNNER_TEMP" --probe-timeout 20s --appserver-probe-runs 2
 
       - name: Teams app-server probe (Windows)
@@ -512,6 +522,16 @@ jobs:
             Write-Host "Codex app-server is unavailable, skipping Teams app-server probe"
             exit 0
           }
+          $env:CODEX_HELPER_TEAMS_PROFILE = "ci-appserver-probe"
+          $env:CODEX_HELPER_TEAMS_TENANT_ID = "ci-tenant"
+          $env:CODEX_HELPER_TEAMS_CLIENT_ID = "ci-client"
+          $env:CODEX_HELPER_TEAMS_READ_CLIENT_ID = "ci-read-client"
+          $env:CODEX_HELPER_TEAMS_FULL_CLIENT_ID = "ci-full-client"
+          $env:CODEX_HELPER_TEAMS_FILE_WRITE_CLIENT_ID = "ci-file-client"
+          $env:CODEX_HELPER_TEAMS_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-token.json"
+          $env:CODEX_HELPER_TEAMS_READ_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-read-token.json"
+          $env:CODEX_HELPER_TEAMS_FULL_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-full-token.json"
+          $env:CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-file-token.json"
           go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path $codexCommand.Source --workdir $env:RUNNER_TEMP --probe-timeout 20s --appserver-probe-runs 2
 
       - name: Codex upgrade integration (system npm, Linux/macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,7 +532,14 @@ jobs:
           $env:CODEX_HELPER_TEAMS_READ_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-read-token.json"
           $env:CODEX_HELPER_TEAMS_FULL_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-full-token.json"
           $env:CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-file-token.json"
-          go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path $codexCommand.Source --workdir $env:RUNNER_TEMP --probe-timeout 20s --appserver-probe-runs 2
+          $codexPath = $codexCommand.Source
+          if ($codexPath -and $codexPath.EndsWith(".ps1", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $cmdCandidate = [System.IO.Path]::ChangeExtension($codexPath, ".cmd")
+            if (Test-Path -LiteralPath $cmdCandidate) {
+              $codexPath = $cmdCandidate
+            }
+          }
+          go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path $codexPath --workdir $env:RUNNER_TEMP --probe-timeout 20s --appserver-probe-runs 2
 
       - name: Codex upgrade integration (system npm, Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/codex-release-monitor.yml
+++ b/.github/workflows/codex-release-monitor.yml
@@ -277,6 +277,12 @@ jobs:
           $env:CODEX_HELPER_TEAMS_FULL_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-full-token.json"
           $env:CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-file-token.json"
           $codexPath = (Get-Command codex).Source
+          if ($codexPath -and $codexPath.EndsWith(".ps1", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $cmdCandidate = [System.IO.Path]::ChangeExtension($codexPath, ".cmd")
+            if (Test-Path -LiteralPath $cmdCandidate) {
+              $codexPath = $cmdCandidate
+            }
+          }
           go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path $codexPath --workdir $env:RUNNER_TEMP --probe-timeout 20s --appserver-probe-runs 2
 
       - name: Write platform result

--- a/.github/workflows/codex-release-monitor.yml
+++ b/.github/workflows/codex-release-monitor.yml
@@ -235,6 +235,16 @@ jobs:
             echo "Codex app-server is unavailable for ${CODEX_VERSION}, skipping Teams app-server probe"
             exit 0
           fi
+          export CODEX_HELPER_TEAMS_PROFILE=ci-appserver-probe
+          export CODEX_HELPER_TEAMS_TENANT_ID=ci-tenant
+          export CODEX_HELPER_TEAMS_CLIENT_ID=ci-client
+          export CODEX_HELPER_TEAMS_READ_CLIENT_ID=ci-read-client
+          export CODEX_HELPER_TEAMS_FULL_CLIENT_ID=ci-full-client
+          export CODEX_HELPER_TEAMS_FILE_WRITE_CLIENT_ID=ci-file-client
+          export CODEX_HELPER_TEAMS_TOKEN_CACHE="$RUNNER_TEMP/teams-appserver-token.json"
+          export CODEX_HELPER_TEAMS_READ_TOKEN_CACHE="$RUNNER_TEMP/teams-appserver-read-token.json"
+          export CODEX_HELPER_TEAMS_FULL_TOKEN_CACHE="$RUNNER_TEMP/teams-appserver-full-token.json"
+          export CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE="$RUNNER_TEMP/teams-appserver-file-token.json"
           go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path "$(command -v codex)" --workdir "$RUNNER_TEMP" --probe-timeout 20s --appserver-probe-runs 2
 
       - name: Teams app-server probe (Windows)
@@ -256,6 +266,16 @@ jobs:
             Write-Host "Codex app-server is unavailable for $env:CODEX_VERSION, skipping Teams app-server probe"
             exit 0
           }
+          $env:CODEX_HELPER_TEAMS_PROFILE = "ci-appserver-probe"
+          $env:CODEX_HELPER_TEAMS_TENANT_ID = "ci-tenant"
+          $env:CODEX_HELPER_TEAMS_CLIENT_ID = "ci-client"
+          $env:CODEX_HELPER_TEAMS_READ_CLIENT_ID = "ci-read-client"
+          $env:CODEX_HELPER_TEAMS_FULL_CLIENT_ID = "ci-full-client"
+          $env:CODEX_HELPER_TEAMS_FILE_WRITE_CLIENT_ID = "ci-file-client"
+          $env:CODEX_HELPER_TEAMS_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-token.json"
+          $env:CODEX_HELPER_TEAMS_READ_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-read-token.json"
+          $env:CODEX_HELPER_TEAMS_FULL_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-full-token.json"
+          $env:CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE = Join-Path $env:RUNNER_TEMP "teams-appserver-file-token.json"
           $codexPath = (Get-Command codex).Source
           go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path $codexPath --workdir $env:RUNNER_TEMP --probe-timeout 20s --appserver-probe-runs 2
 

--- a/.github/workflows/codex-release-monitor.yml
+++ b/.github/workflows/codex-release-monitor.yml
@@ -224,6 +224,41 @@ jobs:
           go test ./internal/cloudgate -run 'TestCodexPatchIntegration|TestCodexPatchedYoloLaunchIntegration' -count=1 -v
           go test ./internal/cli -run 'TestProbeCodexIntegration|TestRunCodexNewSessionRealCodexYoloIntegration' -count=1 -v
 
+      - name: Teams app-server probe (Linux/macOS)
+        if: runner.os != 'Windows'
+        id: appserver_probe_unix
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! codex app-server --help >/dev/null 2>&1; then
+            echo "Codex app-server is unavailable for ${CODEX_VERSION}, skipping Teams app-server probe"
+            exit 0
+          fi
+          go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path "$(command -v codex)" --workdir "$RUNNER_TEMP" --probe-timeout 20s --appserver-probe-runs 2
+
+      - name: Teams app-server probe (Windows)
+        if: runner.os == 'Windows'
+        id: appserver_probe_windows
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          $appServerAvailable = $false
+          try {
+            & codex app-server --help *> $null
+            $appServerAvailable = ($LASTEXITCODE -eq 0)
+          } catch {
+            $appServerAvailable = $false
+          }
+          if (-not $appServerAvailable) {
+            Write-Host "Codex app-server is unavailable for $env:CODEX_VERSION, skipping Teams app-server probe"
+            exit 0
+          }
+          $codexPath = (Get-Command codex).Source
+          go run ./cmd/codex-proxy teams doctor --appserver-probe --codex-path $codexPath --workdir $env:RUNNER_TEMP --probe-timeout 20s --appserver-probe-runs 2
+
       - name: Write platform result
         if: always()
         shell: bash
@@ -231,15 +266,19 @@ jobs:
           RUNNER_OS: ${{ runner.os }}
           PROBE_OUTCOME_UNIX: ${{ steps.wrapper_probe_unix.outcome }}
           PROBE_OUTCOME_WINDOWS: ${{ steps.wrapper_probe_windows.outcome }}
+          APPSERVER_OUTCOME_UNIX: ${{ steps.appserver_probe_unix.outcome }}
+          APPSERVER_OUTCOME_WINDOWS: ${{ steps.appserver_probe_windows.outcome }}
           SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
         run: |
           set -euo pipefail
           status="fail"
           probe_outcome="$PROBE_OUTCOME_UNIX"
+          appserver_outcome="$APPSERVER_OUTCOME_UNIX"
           if [ "$RUNNER_OS" = "Windows" ]; then
             probe_outcome="$PROBE_OUTCOME_WINDOWS"
+            appserver_outcome="$APPSERVER_OUTCOME_WINDOWS"
           fi
-          if [ "$probe_outcome" = "success" ] && [ "$SMOKE_OUTCOME" = "success" ]; then
+          if [ "$probe_outcome" = "success" ] && [ "$SMOKE_OUTCOME" = "success" ] && [ "$appserver_outcome" = "success" ]; then
             status="pass"
           fi
           mkdir -p results
@@ -255,10 +294,10 @@ jobs:
           path: results/${{ env.PLATFORM_NAME }}-${{ env.CODEX_VERSION }}.json
 
       - name: Fail when probe or smoke failed
-        if: steps.smoke.outcome != 'success' || (runner.os == 'Windows' && steps.wrapper_probe_windows.outcome != 'success') || (runner.os != 'Windows' && steps.wrapper_probe_unix.outcome != 'success')
+        if: steps.smoke.outcome != 'success' || (runner.os == 'Windows' && (steps.wrapper_probe_windows.outcome != 'success' || steps.appserver_probe_windows.outcome != 'success')) || (runner.os != 'Windows' && (steps.wrapper_probe_unix.outcome != 'success' || steps.appserver_probe_unix.outcome != 'success'))
         shell: bash
         run: |
-          echo "Codex wrapper probe or patch+yolo smoke failed on ${PLATFORM_NAME}" >&2
+          echo "Codex wrapper probe, Teams app-server probe, or patch+yolo smoke failed on ${PLATFORM_NAME}" >&2
           exit 1
 
   test-linux-distros:

--- a/internal/teams/live_simulated_ci_test.go
+++ b/internal/teams/live_simulated_ci_test.go
@@ -1,0 +1,240 @@
+package teams
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	teamstore "github.com/baaaaaaaka/codex-helper/internal/teams/store"
+)
+
+func TestSimulatedLiveTeamsRenderCasesRoundTripThroughGraphCI(t *testing.T) {
+	graph, captured := newSimulatedLiveGraph(t)
+	ctx := context.Background()
+
+	formattingHTML := RenderTeamsHTML(TeamsRenderInput{
+		Surface: TeamsRenderSurfaceOutbox,
+		Kind:    TeamsRenderAssistant,
+		Text: strings.Join([]string{
+			"## SIM-FORMAT summary",
+			"",
+			"- **bold** `inline <tag>`",
+			"",
+			"```go",
+			`fmt.Println("<teams>")`,
+			"```",
+		}, "\n"),
+	})
+	freezeHTML := renderTeamsFreezeNoticeHTML(
+		"https://teams.microsoft.com/l/chat/control-chat/0",
+		"r SIM-FREEZE",
+		"SIM-FREEZE safe line",
+	)
+	oaiFilteredHTML := renderFinalOutboxBodyHTML(teamstore.OutboxMessage{
+		Kind: "final",
+		Body: strings.Join([]string{
+			"SIM-OAI visible answer",
+			"",
+			"<oai-mem-citation>",
+			"<citation_entries>",
+			"MEMORY.md:1-2|note=[hidden]",
+			"</citation_entries>",
+			"<rollout_ids>",
+			"00000000-0000-0000-0000-000000000000",
+			"</rollout_ids>",
+			"</oai-mem-citation>",
+		}, "\n"),
+	})
+	for _, tc := range []struct {
+		name string
+		html string
+	}{
+		{name: "formatting", html: formattingHTML},
+		{name: "freeze", html: freezeHTML},
+		{name: "oai-memory-filter", html: oaiFilteredHTML},
+	} {
+		if _, err := graph.SendHTML(ctx, "chat-1", tc.html); err != nil {
+			t.Fatalf("%s SendHTML error: %v", tc.name, err)
+		}
+	}
+
+	var tableRows []string
+	tableRows = append(tableRows, "| Case | Value | Notes |")
+	tableRows = append(tableRows, "| --- | --- | --- |")
+	for i := 0; i < 80; i++ {
+		tableRows = append(tableRows, fmt.Sprintf("SIM-TABLE row %02d | `a|b` <x> | [safe](https://example.com/%02d)", i, i))
+	}
+	tableChunks := PlanTeamsHTMLChunks(TeamsRenderInput{
+		Kind: TeamsRenderAssistant,
+		Text: strings.Join(tableRows, "\n"),
+	}, TeamsRenderOptions{
+		TargetLimitBytes: 1400,
+		HardLimitBytes:   1800,
+	})
+	if len(tableChunks) < 2 {
+		t.Fatalf("simulated live table stress should split into multiple Teams messages, got %d", len(tableChunks))
+	}
+	for i, chunk := range tableChunks {
+		if chunk.ByteLength > 1800 {
+			t.Fatalf("table chunk %d byte length = %d, want <= 1800", i, chunk.ByteLength)
+		}
+		if _, err := graph.SendHTML(ctx, "chat-1", chunk.HTML); err != nil {
+			t.Fatalf("table chunk %d SendHTML error: %v", i, err)
+		}
+	}
+
+	messages, err := graph.ListMessages(ctx, "chat-1", 50)
+	if err != nil {
+		t.Fatalf("ListMessages error: %v", err)
+	}
+	if got, want := len(messages), 3+len(tableChunks); got != want {
+		t.Fatalf("captured messages = %d, want %d; raw=%#v", got, want, captured())
+	}
+
+	var plain strings.Builder
+	for _, msg := range messages {
+		if msg.Body.ContentType != "html" {
+			t.Fatalf("captured content type = %q, want html", msg.Body.ContentType)
+		}
+		plain.WriteString(PlainTextFromTeamsHTML(msg.Body.Content))
+		plain.WriteByte('\n')
+	}
+	joined := plain.String()
+	for _, want := range []string{
+		"SIM-FORMAT summary",
+		`fmt.Println("<teams>")`,
+		"SIM-FREEZE safe line",
+		"Step 2: Send: r SIM-FREEZE",
+		"SIM-OAI visible answer",
+		"SIM-TABLE row 00",
+		"SIM-TABLE row 79",
+		"safe (https://example.com/79)",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("simulated live Graph round-trip missing %q in:\n%s", want, joined)
+		}
+	}
+	for _, forbidden := range []string{
+		"oai-mem-citation",
+		"MEMORY.md",
+		"rollout_ids",
+		"https://teams.microsoft.com/l/chat/control-chat/0",
+	} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("simulated live Graph round-trip leaked %q in:\n%s", forbidden, joined)
+		}
+	}
+}
+
+func TestSimulatedLiveHelperE2EControlWorkAndStatusCI(t *testing.T) {
+	var createdTopic string
+	graph, sent := newBridgeCreateChatGraph(t, &createdTopic)
+	store := newBridgeTestStore(t)
+	executor := &recordingExecutor{result: ExecutionResult{
+		Text:          "echo: SIM-HELPER prompt",
+		CodexThreadID: "thread-sim-helper",
+		CodexTurnID:   "turn-sim-helper",
+	}}
+	bridge := newBridgeTestBridge(graph, store, executor)
+	bridge.reg.Sessions = nil
+
+	workDir := t.TempDir()
+	if err := bridge.handleControlMessage(context.Background(), bridgeTestMessageWithText("control-new", "new "+workDir+" -- SIM-HELPER task"), "new "+workDir+" -- SIM-HELPER task"); err != nil {
+		t.Fatalf("control new error: %v", err)
+	}
+	session := bridge.reg.SessionByID("s001")
+	if session == nil || session.ChatID != "work-chat" || session.Cwd != workDir {
+		t.Fatalf("created session mismatch: %#v", bridge.reg.Sessions)
+	}
+	if createdTopic == "" || strings.Contains(createdTopic, workDir) {
+		t.Fatalf("created topic = %q, want non-empty safe title without full path", createdTopic)
+	}
+
+	if err := bridge.handleSessionMessage(context.Background(), session.ChatID, bridgeTestMessageWithText("work-prompt", "SIM-HELPER prompt"), "SIM-HELPER prompt"); err != nil {
+		t.Fatalf("work prompt error: %v", err)
+	}
+	if err := bridge.handleSessionMessage(context.Background(), session.ChatID, bridgeTestMessageWithText("work-status", "helper status"), "helper status"); err != nil {
+		t.Fatalf("work status error: %v", err)
+	}
+
+	joined := sentPlainJoined(*sent)
+	requirePlainTextInOrder(t, joined,
+		"Work chat created: s001",
+		"Codex will start automatically",
+		"search for: s001",
+		"Codex is working. Request accepted.",
+		"echo: SIM-HELPER prompt",
+		"STATUS: Work chat",
+	)
+	if got := executor.prompts; len(got) != 1 || !strings.Contains(got[0], "SIM-HELPER prompt") || !strings.Contains(got[0], ArtifactManifestFenceInfo) {
+		t.Fatalf("executor prompts = %#v, want one prompt with artifact handoff instructions", got)
+	}
+
+	state, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load state error: %v", err)
+	}
+	var completed int
+	for _, turn := range state.Turns {
+		if turn.SessionID == session.ID && turn.Status == teamstore.TurnStatusCompleted {
+			completed++
+		}
+	}
+	if completed != 1 {
+		t.Fatalf("completed turns for %s = %d, want 1; turns=%#v", session.ID, completed, state.Turns)
+	}
+}
+
+func newSimulatedLiveGraph(t *testing.T) (*GraphClient, func() []ChatMessage) {
+	t.Helper()
+	var mu sync.Mutex
+	var messages []ChatMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/chats/chat-1/messages":
+			var payload struct {
+				Body struct {
+					ContentType string `json:"contentType"`
+					Content     string `json:"content"`
+				} `json:"body"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode message payload: %v", err)
+			}
+			if payload.Body.ContentType != "html" {
+				t.Fatalf("contentType = %q, want html", payload.Body.ContentType)
+			}
+			mu.Lock()
+			id := fmt.Sprintf("message-%02d", len(messages)+1)
+			msg := ChatMessage{ID: id, ChatID: "chat-1", CreatedDateTime: "2026-05-14T00:00:00Z", MessageType: "message"}
+			msg.Body.ContentType = payload.Body.ContentType
+			msg.Body.Content = payload.Body.Content
+			messages = append([]ChatMessage{msg}, messages...)
+			mu.Unlock()
+			if err := json.NewEncoder(w).Encode(msg); err != nil {
+				t.Fatalf("encode message response: %v", err)
+			}
+		case r.Method == http.MethodGet && r.URL.Path == "/chats/chat-1/messages":
+			mu.Lock()
+			out := append([]ChatMessage(nil), messages...)
+			mu.Unlock()
+			if err := json.NewEncoder(w).Encode(map[string]any{"value": out}); err != nil {
+				t.Fatalf("encode messages response: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected Graph request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	t.Cleanup(server.Close)
+	return newTestGraphClient(&fakeGraphAuth{token: "access"}, server, nil), func() []ChatMessage {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]ChatMessage(nil), messages...)
+	}
+}

--- a/scripts/ci/teams_installed_smoke.ps1
+++ b/scripts/ci/teams_installed_smoke.ps1
@@ -1,0 +1,73 @@
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+$runnerTemp = $env:RUNNER_TEMP
+if (-not $runnerTemp) {
+  $runnerTemp = [System.IO.Path]::GetTempPath()
+}
+$base = Join-Path $runnerTemp "codex-helper-teams-installed-smoke"
+if (Test-Path $base) {
+  Remove-Item -Recurse -Force $base
+}
+New-Item -ItemType Directory -Force -Path (Join-Path $base "bin") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $base "codex-home") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $base "cache") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $base "appdata") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $base "localappdata") | Out-Null
+
+$bin = Join-Path $base "bin\codex-proxy.exe"
+go build -trimpath -o $bin ./cmd/codex-proxy
+
+$env:CODEX_HOME = Join-Path $base "codex-home"
+$env:APPDATA = Join-Path $base "appdata"
+$env:LOCALAPPDATA = Join-Path $base "localappdata"
+$env:NO_COLOR = "1"
+$env:CODEX_HELPER_TEAMS_PROFILE = "ci-installed-smoke"
+$env:CODEX_HELPER_TEAMS_TENANT_ID = "ci-tenant"
+$env:CODEX_HELPER_TEAMS_CLIENT_ID = "ci-client"
+$env:CODEX_HELPER_TEAMS_READ_CLIENT_ID = "ci-read-client"
+$env:CODEX_HELPER_TEAMS_FULL_CLIENT_ID = "ci-full-client"
+$env:CODEX_HELPER_TEAMS_FILE_WRITE_CLIENT_ID = "ci-file-client"
+$env:CODEX_HELPER_TEAMS_TOKEN_CACHE = Join-Path $base "cache\teams-token.json"
+$env:CODEX_HELPER_TEAMS_READ_TOKEN_CACHE = Join-Path $base "cache\teams-read-token.json"
+$env:CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE = Join-Path $base "cache\teams-file-token.json"
+
+function Invoke-Smoke {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string[]]$CommandArgs
+  )
+  $out = Join-Path $base "$Name.txt"
+  & $bin @CommandArgs 2>&1 | Tee-Object -FilePath $out
+  if ($LASTEXITCODE -ne 0) {
+    throw "smoke command $Name failed with exit code $LASTEXITCODE"
+  }
+  return $out
+}
+
+function Assert-Contains {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Text
+  )
+  $content = Get-Content -LiteralPath $Path -Raw
+  if (-not $content.Contains($Text)) {
+    throw "expected $Path to contain: $Text`n---- $Path ----`n$content"
+  }
+}
+
+& $bin --version | Out-Null
+
+$setup = Invoke-Smoke -Name "setup" -CommandArgs @("teams", "setup")
+$status = Invoke-Smoke -Name "status" -CommandArgs @("teams", "status")
+$control = Invoke-Smoke -Name "control-print" -CommandArgs @("teams", "control", "--print")
+$doctor = Invoke-Smoke -Name "doctor" -CommandArgs @("teams", "doctor")
+$serviceDoctor = Invoke-Smoke -Name "service-doctor" -CommandArgs @("teams", "service", "doctor")
+
+Assert-Contains -Path $setup -Text "Teams setup checklist"
+Assert-Contains -Path $status -Text "Teams status"
+Assert-Contains -Path $status -Text "Control chat: unavailable"
+Assert-Contains -Path $control -Text "Teams control chat: unavailable"
+Assert-Contains -Path $doctor -Text "Teams doctor"
+Assert-Contains -Path $doctor -Text "Graph: not checked"
+Assert-Contains -Path $serviceDoctor -Text "Teams service backend:"

--- a/scripts/ci/teams_installed_smoke.ps1
+++ b/scripts/ci/teams_installed_smoke.ps1
@@ -38,9 +38,18 @@ function Invoke-Smoke {
     [Parameter(Mandatory = $true)][string[]]$CommandArgs
   )
   $out = Join-Path $base "$Name.txt"
-  & $bin @CommandArgs 2>&1 | Tee-Object -FilePath $out
-  if ($LASTEXITCODE -ne 0) {
-    throw "smoke command $Name failed with exit code $LASTEXITCODE"
+  $nativePreference = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    $commandOutput = & $bin @CommandArgs 2>&1
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $PSNativeCommandUseErrorActionPreference = $nativePreference
+  }
+  $commandOutput | Set-Content -LiteralPath $out
+  $commandOutput | ForEach-Object { Write-Host $_ }
+  if ($exitCode -ne 0) {
+    throw "smoke command $Name failed with exit code $exitCode"
   }
   return $out
 }

--- a/scripts/ci/teams_installed_smoke.sh
+++ b/scripts/ci/teams_installed_smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/codex-helper-teams-installed-smoke"
+rm -rf "$base"
+mkdir -p "$base/bin" "$base/codex-home" "$base/config" "$base/cache"
+
+bin="$base/bin/codex-proxy"
+go build -trimpath -o "$bin" ./cmd/codex-proxy
+
+export CODEX_HOME="$base/codex-home"
+export XDG_CONFIG_HOME="$base/config"
+export XDG_CACHE_HOME="$base/cache"
+export NO_COLOR=1
+export CODEX_HELPER_TEAMS_PROFILE=ci-installed-smoke
+export CODEX_HELPER_TEAMS_TENANT_ID=ci-tenant
+export CODEX_HELPER_TEAMS_CLIENT_ID=ci-client
+export CODEX_HELPER_TEAMS_READ_CLIENT_ID=ci-read-client
+export CODEX_HELPER_TEAMS_FULL_CLIENT_ID=ci-full-client
+export CODEX_HELPER_TEAMS_FILE_WRITE_CLIENT_ID=ci-file-client
+export CODEX_HELPER_TEAMS_WSL_SERVICE_BACKEND=systemd
+export CODEX_HELPER_TEAMS_TOKEN_CACHE="$base/cache/teams-token.json"
+export CODEX_HELPER_TEAMS_READ_TOKEN_CACHE="$base/cache/teams-read-token.json"
+export CODEX_HELPER_TEAMS_FILE_WRITE_TOKEN_CACHE="$base/cache/teams-file-token.json"
+
+run_smoke() {
+  local name="$1"
+  shift
+  local out="$base/${name}.txt"
+  "$bin" "$@" 2>&1 | tee "$out"
+}
+
+assert_contains() {
+  local file="$1"
+  local text="$2"
+  if ! grep -Fq "$text" "$file"; then
+    echo "expected $file to contain: $text" >&2
+    echo "---- $file ----" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+"$bin" --version >/dev/null
+
+run_smoke setup teams setup
+run_smoke status teams status
+run_smoke control-print teams control --print
+run_smoke doctor teams doctor
+run_smoke service-doctor teams service doctor
+
+assert_contains "$base/setup.txt" "Teams setup checklist"
+assert_contains "$base/status.txt" "Teams status"
+assert_contains "$base/status.txt" "Control chat: unavailable"
+assert_contains "$base/control-print.txt" "Teams control chat: unavailable"
+assert_contains "$base/doctor.txt" "Teams doctor"
+assert_contains "$base/doctor.txt" "Graph: not checked"
+assert_contains "$base/service-doctor.txt" "Teams service backend:"


### PR DESCRIPTION
Adds CI-safe Teams coverage for simulated live Graph flows, helper control/work/status flow, artifact and attachment regressions in existing CI patterns, installed-binary local smoke checks, app-server probes, and old-distro/non-root Teams coverage.\n\nLocal verification before opening PR:\n- Docker Go 1.24.12 targeted Teams test pattern passed\n- Docker Go 1.24.12 Linux installed-binary smoke passed\n- bash -n scripts/ci/teams_installed_smoke.sh passed\n- YAML parse for ci.yml and codex-release-monitor.yml passed\n- git diff --check passed\n\nNote: local host has no go/pwsh binaries; Go checks were run through Docker and Windows PowerShell smoke is left for GitHub Actions.