### PR TITLE
Resolve latest helper release via redirect first

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -397,14 +397,8 @@ function New-ProfilePathLine([string]$pathValue) {
 
 function Get-LatestTag([string]$repo) {
   $apiUri = "$apiBase/repos/$repo/releases/latest"
-  try {
-    $resp = Invoke-RestMethod -Uri $apiUri -Headers @{ "User-Agent" = "codex-proxy-install" }
-    if ($resp.tag_name) { return [string]$resp.tag_name }
-  } catch {
-    # Fall back to parsing the redirect URL below.
-  }
-
   $latestUri = "$releaseBase/$repo/releases/latest"
+  $redirectError = $null
   try {
     $resp = Invoke-WebRequest -Uri $latestUri -Headers @{ "User-Agent" = "codex-proxy-install" } -UseBasicParsing
     $finalUri = $resp.BaseResponse.ResponseUri
@@ -414,8 +408,22 @@ function Get-LatestTag([string]$repo) {
         return [string]$tag
       }
     }
+    $redirectError = "missing tag in redirect URL"
   } catch {
-    throw "Failed to determine latest tag from $latestUri"
+    $redirectError = $_.Exception.Message
+  }
+
+  $apiError = $null
+  try {
+    $resp = Invoke-RestMethod -Uri $apiUri -Headers @{ "User-Agent" = "codex-proxy-install" }
+    if ($resp.tag_name) { return [string]$resp.tag_name }
+    $apiError = "missing tag_name in GitHub API response"
+  } catch {
+    $apiError = $_.Exception.Message
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($redirectError) -or -not [string]::IsNullOrWhiteSpace($apiError)) {
+    throw "Failed to determine latest tag from $latestUri; API fallback $apiUri failed: $apiError"
   }
 
   throw "Failed to determine latest tag from $apiUri"

--- a/install.sh
+++ b/install.sh
@@ -727,20 +727,20 @@ get_latest_tag_from_redirect() {
 get_latest_tag() {
   tmp="$1"
   tag=""
-  if http_get "$api_base/repos/$repo/releases/latest" "$tmp"; then
-    if have_cmd sed; then
-      tag="$(sed -n 's/.*\"tag_name\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p' "$tmp" | head -n 1 || true)"
-    fi
-  fi
-  if [ -n "${tag:-}" ]; then
-    printf "%s" "$tag"
-    return 0
-  fi
   if tag="$(get_latest_tag_from_redirect)"; then
     if [ -n "${tag:-}" ]; then
       printf "%s" "$tag"
       return 0
     fi
+  fi
+  if http_get "$api_base/repos/$repo/releases/latest" "$tmp"; then
+    if have_cmd sed; then
+      tag="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tmp" | head -n 1 || true)"
+    fi
+  fi
+  if [ -n "${tag:-}" ]; then
+    printf "%s" "$tag"
+    return 0
   fi
   echo "Failed to determine latest version automatically; pass --version vX.Y.Z" >&2
   return 1

--- a/install_scripts_test.go
+++ b/install_scripts_test.go
@@ -13,12 +13,25 @@ import (
 	"testing"
 )
 
-func TestInstallShLatestViaAPI(t *testing.T) {
-	runInstallSh(t, false, false)
+func TestInstallShLatestUsesRedirectBeforeAPI(t *testing.T) {
+	run := newInstallShRun(t, false, false)
+	apiHitsPath := filepath.Join(t.TempDir(), "api-hits.txt")
+	run.env = overrideEnv(run.env, "CODEX_PROXY_TEST_API_HITS", apiHitsPath)
+
+	runInstallShCommand(t, run)
+
+	assertFileMissingOrEmpty(t, apiHitsPath)
 }
 
-func TestInstallShLatestViaRedirect(t *testing.T) {
-	runInstallSh(t, true, false)
+func TestInstallShLatestFallsBackToAPIWhenRedirectUnavailable(t *testing.T) {
+	run := newInstallShRun(t, false, false)
+	apiHitsPath := filepath.Join(t.TempDir(), "api-hits.txt")
+	run.env = overrideEnv(run.env, "CODEX_PROXY_TEST_API_HITS", apiHitsPath)
+	run.env = overrideEnv(run.env, "CODEX_PROXY_TEST_LATEST_URL", "https://github.com/owner/name/releases/latest")
+
+	runInstallShCommand(t, run)
+
+	assertFileContains(t, apiHitsPath, "api\n")
 }
 
 func TestInstallShKeepsPathSetupWhenInstallDirAlreadySet(t *testing.T) {
@@ -924,6 +937,9 @@ fi
 
 case "$url" in
   *"/repos/"*"/releases/latest")
+    if [ -n "${CODEX_PROXY_TEST_API_HITS:-}" ]; then
+      printf "api\n" >> "$CODEX_PROXY_TEST_API_HITS"
+    fi
     if [ "${CODEX_PROXY_TEST_API_FAIL:-}" = "1" ]; then
       exit 22
     fi
@@ -989,6 +1005,31 @@ func runInstallShCommandWithCmd(t *testing.T, cmd *exec.Cmd) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("install.sh failed: %v\n%s", err, string(output))
+	}
+}
+
+func assertFileMissingOrEmpty(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected %s to be empty or absent, got %q", path, string(data))
+	}
+}
+
+func assertFileContains(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("expected %s to contain %q, got %q", path, want, string(data))
 	}
 }
 

--- a/install_scripts_windows_test.go
+++ b/install_scripts_windows_test.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 )
 
-func TestInstallPs1LatestViaAPI(t *testing.T) {
+func TestInstallPs1LatestViaRedirect(t *testing.T) {
 	runInstallPs1(t, false, false)
 }
 
-func TestInstallPs1LatestViaRedirect(t *testing.T) {
+func TestInstallPs1LatestSurvivesAPIUnavailable(t *testing.T) {
 	runInstallPs1(t, true, false)
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -338,17 +338,17 @@ func normalizeVersion(v string) string {
 }
 
 func fetchLatestRelease(ctx context.Context, repo string, timeout time.Duration) (string, string, error) {
-	tag, ver, err := fetchLatestReleaseAPI(ctx, repo, timeout)
-	if err == nil {
-		return tag, ver, nil
-	}
-
 	tag, ver, redirectErr := fetchLatestReleaseRedirect(ctx, repo, timeout)
 	if redirectErr == nil {
 		return tag, ver, nil
 	}
 
-	return "", "", fmt.Errorf("release lookup failed: %v; redirect fallback failed: %v", err, redirectErr)
+	tag, ver, err := fetchLatestReleaseAPI(ctx, repo, timeout)
+	if err == nil {
+		return tag, ver, nil
+	}
+
+	return "", "", fmt.Errorf("release redirect lookup failed: %v; API fallback failed: %v", redirectErr, err)
 }
 
 func fetchLatestReleaseAPI(ctx context.Context, repo string, timeout time.Duration) (string, string, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -50,12 +50,13 @@ func TestCheckForUpdateAvailable(t *testing.T) {
 	}
 }
 
-func TestCheckForUpdateFallbackRedirect(t *testing.T) {
+func TestCheckForUpdateUsesRedirectBeforeAPI(t *testing.T) {
 	requireRuntimeAsset(t)
 	tag := "v1.4.0"
 	ver := "1.4.0"
 
-	server := newRedirectReleaseServer(t, "owner/name", tag)
+	apiCalls := 0
+	server := newRedirectReleaseServer(t, "owner/name", tag, &apiCalls)
 	defer server.Close()
 
 	restore := overrideGitHubBases(server.URL)
@@ -75,6 +76,9 @@ func TestCheckForUpdateFallbackRedirect(t *testing.T) {
 	}
 	if st.RemoteTag != tag {
 		t.Fatalf("expected remote tag %s, got %s", tag, st.RemoteTag)
+	}
+	if apiCalls != 0 {
+		t.Fatalf("expected redirect-first latest lookup to skip GitHub API, got %d API calls", apiCalls)
 	}
 }
 
@@ -607,12 +611,15 @@ func newReleaseListServer(t *testing.T, releases []testReleaseAsset) *httptest.S
 	return httptest.NewServer(http.HandlerFunc(handler))
 }
 
-func newRedirectReleaseServer(t *testing.T, repo, tag string) *httptest.Server {
+func newRedirectReleaseServer(t *testing.T, repo, tag string, apiCalls *int) *httptest.Server {
 	t.Helper()
 	tagPath := "/" + repo + "/releases/tag/" + tag
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(r.URL.Path, "/repos/") && strings.Contains(r.URL.Path, "/releases/latest"):
+			if apiCalls != nil {
+				*apiCalls = *apiCalls + 1
+			}
 			http.Error(w, "api unavailable", http.StatusServiceUnavailable)
 		case strings.Contains(r.URL.Path, "/releases/latest"):
 			w.Header().Set("Location", tagPath)

--- a/scripts/tests/test_windows_install_script.py
+++ b/scripts/tests/test_windows_install_script.py
@@ -9,6 +9,19 @@ INSTALL_PS1 = REPO_ROOT / "install.ps1"
 
 
 class WindowsInstallScriptTests(unittest.TestCase):
+    def test_latest_resolution_uses_redirect_before_api(self) -> None:
+        script = INSTALL_PS1.read_text(encoding="utf-8")
+
+        function_start = script.index("function Get-LatestTag")
+        function_end = script.index("Assert-DiskSpace -label", function_start)
+        latest_function = script[function_start:function_end]
+
+        self.assertLess(
+            latest_function.index("Invoke-WebRequest -Uri $latestUri"),
+            latest_function.index("Invoke-RestMethod -Uri $apiUri"),
+        )
+        self.assertIn("API fallback", latest_function)
+
     def test_installer_waits_for_existing_helper_before_replacing_binary(self) -> None:
         script = INSTALL_PS1.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- resolve installer latest release tags through github.com releases/latest redirect before falling back to api.github.com
- apply the same redirect-first order to Windows install.ps1 and Go update checks
- add regression coverage proving normal latest resolution skips the GitHub API and still falls back when redirect parsing fails

## Tests
- go test . -count=1
- go test ./internal/update -count=1
- go test ./internal/cli -run 'TestTeamsAutoUpdate' -count=1\n- python3 scripts/tests/test_windows_install_script.py\n\nNote: local Linux host does not have pwsh/powershell installed, so Windows PowerShell execution coverage is expected to come from CI.