### PR TITLE
fix(teams): activate managed runtime through fresh restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,12 +227,12 @@ jobs:
           go test ./internal/update -count=1 -run 'Test(Probe.*|PerformUpdatePublishesImmutableRuntimeAndSwitchesActive|ReplaceBinaryReplacesIdleExistingDestinationWindows)$' -v
           go test ./internal/cli -count=1 -run 'Test(CurrentRuntimeOwnsUpdateTarget|PreferredCXPServiceEntryDoesNotUseUnrelatedRuntime|RefreshWindowsStableCXPExecutable.*|EnsureCXPShimForInstallPathNormalizesManagedWindowsCmdShim|CopyExecutableAtomicallyReplacesExistingFile)$' -v
 
-      - name: Reproduce Teams managed-runtime activation mismatch (Linux)
-        if: matrix.shard == 'platform-integration' && runner.os == 'Linux'
+      - name: Teams managed-runtime activation and fresh restart
+        if: matrix.shard == 'platform-integration'
         shell: bash
         run: |
           set -euo pipefail
-          go test ./internal/cli -count=1 -run 'Test(TeamsReleaseAutoUpdaterManagedRuntimeActivationUsesNormalRestart|RestartTeamsHelperAfterActivationPendingUsesInstalledPath)$' -v
+          go test ./internal/cli -count=1 -run 'Test(TeamsReleaseAutoUpdaterManagedRuntimeActivationUsesNormalRestart|TeamsAutoUpdateActivationAfterApply|RestartTeamsHelperAfterActivationPendingUsesInstalledPath)$' -v
 
       - name: Actual candidate-owned update and recovery (Linux/macOS)
         if: matrix.shard == 'platform-integration' && runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,13 @@ jobs:
           go test ./internal/update -count=1 -run 'Test(Probe.*|PerformUpdatePublishesImmutableRuntimeAndSwitchesActive|ReplaceBinaryReplacesIdleExistingDestinationWindows)$' -v
           go test ./internal/cli -count=1 -run 'Test(CurrentRuntimeOwnsUpdateTarget|PreferredCXPServiceEntryDoesNotUseUnrelatedRuntime|RefreshWindowsStableCXPExecutable.*|EnsureCXPShimForInstallPathNormalizesManagedWindowsCmdShim|CopyExecutableAtomicallyReplacesExistingFile)$' -v
 
+      - name: Reproduce Teams managed-runtime activation mismatch (Linux)
+        if: matrix.shard == 'platform-integration' && runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test ./internal/cli -count=1 -run 'Test(TeamsReleaseAutoUpdaterManagedRuntimeActivationUsesNormalRestart|RestartTeamsHelperAfterActivationPendingUsesInstalledPath)$' -v
+
       - name: Actual candidate-owned update and recovery (Linux/macOS)
         if: matrix.shard == 'platform-integration' && runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
           go test ./internal/helperruntime -count=1 -run 'Test(NormalizeVersion|LauncherEnvironment.*|InstallVersion.*|PublishDownloaded.*|EnsureStableEntry.*|Current.*|RecoverPrevious.*|RuntimeProcessIdentity.*)$' -v
           go test ./internal/candidateupdate -count=1 -v
           go test ./internal/update -count=1 -run 'Test(Probe.*|PerformUpdatePublishesImmutableRuntimeAndSwitchesActive|ReplaceBinaryReplacesIdleExistingDestinationWindows)$' -v
-          go test ./internal/cli -count=1 -run 'Test(CurrentRuntimeOwnsUpdateTarget|PreferredCXPServiceEntryDoesNotUseUnrelatedRuntime|RefreshWindowsStableCXPExecutable.*|EnsureCXPShimForInstallPathNormalizesManagedWindowsCmdShim|CopyExecutableAtomicallyReplacesExistingFile)$' -v
+          go test ./internal/cli -count=1 -run 'Test(CurrentRuntimeOwnsUpdateTarget|PreferredCXPServiceEntryDoesNotUseUnrelatedRuntime|RefreshWindowsStableCXPExecutable.*|EnsureCXPShimForInstallPathNormalizesManagedWindowsCmdShim|CopyExecutableAtomicallyReplacesExistingFile|TeamsReleaseAutoUpdaterManagedRuntimeActivationUsesNormalRestart|TeamsAutoUpdateActivationAfterApply|RestartTeamsHelperAfterActivationPendingUsesInstalledPath)$' -v
 
       - name: Actual candidate-owned update and recovery (Linux/macOS)
         if: runner.os != 'Windows'

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -129,7 +129,7 @@ func restartSelfWithExecutable(path string) error {
 	if err != nil {
 		return err
 	}
-	return restartSelfWithResolvedExecutable(exe)
+	return restartSelfWithResolvedExecutableAndEnv(exe, helperruntime.LauncherEnvironment(os.Environ()))
 }
 
 func restartSelfWithResolvedExecutable(exe string) error {
@@ -139,7 +139,7 @@ func restartSelfWithResolvedExecutable(exe string) error {
 func restartSelfWithResolvedExecutableAndEnv(exe string, env []string) error {
 	args := append([]string{exe}, os.Args[1:]...)
 	if runtime.GOOS == "windows" {
-		if err := startSelf(exe, args[1:]); err != nil {
+		if err := startSelf(exe, args[1:], env); err != nil {
 			return err
 		}
 		exitFunc(0)
@@ -180,8 +180,9 @@ func stripReloadBackupSuffix(path string) string {
 	return path
 }
 
-func startRestartProcess(exe string, args []string) error {
+func startRestartProcess(exe string, args []string, env []string) error {
 	c := exec.Command(exe, args...)
+	c.Env = env
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/internal/cli/restart_test.go
+++ b/internal/cli/restart_test.go
@@ -83,7 +83,7 @@ func TestRestartSelfExecsSameBinaryWithCurrentArgs(t *testing.T) {
 	executablePath = func() (string, error) {
 		return exe, nil
 	}
-	startSelf = func(string, []string) error {
+	startSelf = func(string, []string, []string) error {
 		t.Fatal("startSelf should not be used on non-Windows restart")
 		return nil
 	}
@@ -289,7 +289,7 @@ func TestHandleUpdateAndRestartUnifiesCXPShimBeforeExec(t *testing.T) {
 		writeCLIFile(t, installPath, upgradeCXPShimTestScript("1.2.4"), 0o755)
 		return update.ApplyResult{Version: "1.2.4", InstallPath: installPath}, nil
 	}
-	startSelf = func(string, []string) error {
+	startSelf = func(string, []string, []string) error {
 		t.Fatal("startSelf should not be used on non-Windows restart")
 		return nil
 	}
@@ -333,14 +333,11 @@ func TestHandleUpdateAndRestartUnifiesCXPShimBeforeExec(t *testing.T) {
 }
 
 func TestRestartTeamsHelperAfterActivationPendingUsesInstalledPath(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("non-Windows restart uses exec; Windows is covered by process start tests")
-	}
 	lockCLITestHooks(t)
 
 	tmp := t.TempDir()
 	isolateUpgradeTeamsStateForTest(t, tmp)
-	installPath := filepath.Join(tmp, ".local", "bin", "codex-proxy")
+	installPath := filepath.Join(tmp, ".local", "bin", helperpath.BinaryName(runtime.GOOS))
 	if err := os.MkdirAll(filepath.Dir(installPath), 0o755); err != nil {
 		t.Fatalf("mkdir install dir: %v", err)
 	}
@@ -361,20 +358,33 @@ func TestRestartTeamsHelperAfterActivationPendingUsesInstalledPath(t *testing.T)
 		execSelf = prevExecSelf
 		startSelf = prevStartSelf
 	})
-	startSelf = func(string, []string) error {
-		t.Fatal("startSelf should not be used on non-Windows restart")
-		return nil
-	}
 
 	wantErr := errors.New("stop before real exec")
 	var gotExe string
 	var gotArgs []string
 	var gotEnv []string
-	execSelf = func(exe string, args []string, env []string) error {
-		gotExe = exe
-		gotArgs = append([]string{}, args...)
-		gotEnv = append([]string{}, env...)
-		return wantErr
+	if runtime.GOOS == "windows" {
+		execSelf = func(string, []string, []string) error {
+			t.Fatal("execSelf should not be used on Windows restart")
+			return nil
+		}
+		startSelf = func(exe string, args []string, env []string) error {
+			gotExe = exe
+			gotArgs = append([]string{}, args...)
+			gotEnv = append([]string{}, env...)
+			return wantErr
+		}
+	} else {
+		startSelf = func(string, []string, []string) error {
+			t.Fatal("startSelf should not be used on non-Windows restart")
+			return nil
+		}
+		execSelf = func(exe string, args []string, env []string) error {
+			gotExe = exe
+			gotArgs = append([]string{}, args...)
+			gotEnv = append([]string{}, env...)
+			return wantErr
+		}
 	}
 
 	prevArgs := os.Args
@@ -389,8 +399,11 @@ func TestRestartTeamsHelperAfterActivationPendingUsesInstalledPath(t *testing.T)
 		t.Fatalf("exec exe = %q, want installed path %q", gotExe, installPath)
 	}
 	wantArgs := []string{installPath, "teams", "run", "--auto-service=false"}
+	if runtime.GOOS == "windows" {
+		wantArgs = wantArgs[1:]
+	}
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
-		t.Fatalf("exec args = %#v, want %#v", gotArgs, wantArgs)
+		t.Fatalf("restart args = %#v, want %#v", gotArgs, wantArgs)
 	}
 	for _, key := range []string{
 		helperruntime.EnvRuntime,
@@ -400,11 +413,11 @@ func TestRestartTeamsHelperAfterActivationPendingUsesInstalledPath(t *testing.T)
 		helperruntime.EnvDisable,
 		helperruntime.EnvForce,
 	} {
-		if value := envValue(gotEnv, key); value != "" {
+		if value, ok := testEnvValue(gotEnv, key); ok {
 			t.Fatalf("installed-path restart leaked %s=%q into the fresh helper process", key, value)
 		}
 	}
-	if value := envValue(gotEnv, "KEEP_RESTART_TEST"); value != "yes" {
+	if value, ok := testEnvValue(gotEnv, "KEEP_RESTART_TEST"); !ok || value != "yes" {
 		t.Fatalf("installed-path restart lost unrelated environment value %q", value)
 	}
 }
@@ -432,7 +445,7 @@ func TestRestartSelfUsesStablePathWhenRunningReloadBackup(t *testing.T) {
 	executablePath = func() (string, error) {
 		return backup, nil
 	}
-	startSelf = func(string, []string) error {
+	startSelf = func(string, []string, []string) error {
 		t.Fatal("startSelf should not be used on non-Windows restart")
 		return nil
 	}
@@ -486,7 +499,7 @@ func TestRestartSelfUsesStablePathWhenRunningNFSSillyRename(t *testing.T) {
 	executablePath = func() (string, error) {
 		return running, nil
 	}
-	startSelf = func(string, []string) error {
+	startSelf = func(string, []string, []string) error {
 		t.Fatal("startSelf should not be used on non-Windows restart")
 		return nil
 	}

--- a/internal/cli/restart_test.go
+++ b/internal/cli/restart_test.go
@@ -347,6 +347,13 @@ func TestRestartTeamsHelperAfterActivationPendingUsesInstalledPath(t *testing.T)
 	if err := os.WriteFile(installPath, []byte("updated"), 0o755); err != nil {
 		t.Fatalf("write install path: %v", err)
 	}
+	t.Setenv(helperruntime.EnvRuntime, "1")
+	t.Setenv(helperruntime.EnvRuntimeRoot, filepath.Join(tmp, ".cxp-runtime"))
+	t.Setenv(helperruntime.EnvRuntimeVersion, "v1.2.3")
+	t.Setenv(helperruntime.EnvEntryPath, installPath)
+	t.Setenv(helperruntime.EnvDisable, "1")
+	t.Setenv(helperruntime.EnvForce, "1")
+	t.Setenv("KEEP_RESTART_TEST", "yes")
 
 	prevExecSelf := execSelf
 	prevStartSelf := startSelf
@@ -362,9 +369,11 @@ func TestRestartTeamsHelperAfterActivationPendingUsesInstalledPath(t *testing.T)
 	wantErr := errors.New("stop before real exec")
 	var gotExe string
 	var gotArgs []string
+	var gotEnv []string
 	execSelf = func(exe string, args []string, env []string) error {
 		gotExe = exe
 		gotArgs = append([]string{}, args...)
+		gotEnv = append([]string{}, env...)
 		return wantErr
 	}
 
@@ -382,6 +391,21 @@ func TestRestartTeamsHelperAfterActivationPendingUsesInstalledPath(t *testing.T)
 	wantArgs := []string{installPath, "teams", "run", "--auto-service=false"}
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
 		t.Fatalf("exec args = %#v, want %#v", gotArgs, wantArgs)
+	}
+	for _, key := range []string{
+		helperruntime.EnvRuntime,
+		helperruntime.EnvRuntimeRoot,
+		helperruntime.EnvRuntimeVersion,
+		helperruntime.EnvEntryPath,
+		helperruntime.EnvDisable,
+		helperruntime.EnvForce,
+	} {
+		if value := envValue(gotEnv, key); value != "" {
+			t.Fatalf("installed-path restart leaked %s=%q into the fresh helper process", key, value)
+		}
+	}
+	if value := envValue(gotEnv, "KEEP_RESTART_TEST"); value != "yes" {
+		t.Fatalf("installed-path restart lost unrelated environment value %q", value)
 	}
 }
 

--- a/internal/cli/root_command_test.go
+++ b/internal/cli/root_command_test.go
@@ -361,7 +361,7 @@ func TestRestartTeamsHelperFromTeamsLinuxLocalSupervisorSchedulesServiceRestart(
 		t.Fatal("local-supervisor service restart must not exec the current helper process")
 		return nil
 	}
-	startSelf = func(string, []string) error {
+	startSelf = func(string, []string, []string) error {
 		t.Fatal("local-supervisor service restart must not spawn teams run directly")
 		return nil
 	}
@@ -410,7 +410,7 @@ func TestRestartTeamsHelperFromTeamsBlocksOnBeaconJob(t *testing.T) {
 		t.Fatal("helper restart must not exec while beacon work is active")
 		return nil
 	}
-	startSelf = func(string, []string) error {
+	startSelf = func(string, []string, []string) error {
 		t.Fatal("helper restart must not spawn while beacon work is active")
 		return nil
 	}

--- a/internal/cli/teams_auto_update.go
+++ b/internal/cli/teams_auto_update.go
@@ -179,6 +179,10 @@ func (u teamsReleaseAutoUpdater) ApplyWithOptions(ctx context.Context, candidate
 	if err != nil {
 		return teams.HelperAutoUpdateApplyResult{}, err
 	}
+	activationPending, activationReason, err = teamsAutoUpdateActivationAfterApply(activationPending, activationReason, res)
+	if err != nil {
+		return teams.HelperAutoUpdateApplyResult{}, err
+	}
 	if res.RestartRequired {
 		if err := ensureCXPShimForInstallPath(res.InstallPath); err != nil {
 			return teams.HelperAutoUpdateApplyResult{}, err
@@ -203,6 +207,26 @@ func (u teamsReleaseAutoUpdater) ApplyWithOptions(ctx context.Context, candidate
 		ActivationPending:  activationPending,
 		ActivationReason:   activationReason,
 	}, nil
+}
+
+func teamsAutoUpdateActivationAfterApply(preUpdatePending bool, preUpdateReason string, res update.ApplyResult) (bool, string, error) {
+	if !res.RuntimeActivated {
+		return preUpdatePending, preUpdateReason, nil
+	}
+	if res.RestartRequired || strings.TrimSpace(res.PendingReplacePath) != "" {
+		return false, "", fmt.Errorf(
+			"managed runtime update returned contradictory activation state: runtime_activated=%t restart_required=%t pending_replace_path=%q",
+			res.RuntimeActivated,
+			res.RestartRequired,
+			res.PendingReplacePath,
+		)
+	}
+	// RuntimeActivated is the authoritative postcondition for an immutable
+	// runtime update. finalizeHelperUpdateResult still verifies both the
+	// published runtime and the stable entry before Apply returns this state.
+	// The pre-update executable can legitimately remain the old immutable
+	// runtime until the normal fresh-launch restart crosses the stable entry.
+	return false, "", nil
 }
 
 func teamsPendingReplacementMode(applyOpts teams.HelperAutoUpdateApplyOptions) update.PendingReplacementMode {

--- a/internal/cli/teams_auto_update_test.go
+++ b/internal/cli/teams_auto_update_test.go
@@ -587,8 +587,8 @@ func TestTeamsReleaseAutoUpdaterApplyUsesRunningGoBinAndUnifiesManagedDefault(t 
 }
 
 func TestTeamsReleaseAutoUpdaterManagedRuntimeActivationUsesNormalRestart(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("the reported helper activation mismatch occurred on Linux/WSL")
+	if runtime.GOOS == "windows" {
+		t.Skip("managed-runtime executable fixture uses a POSIX script")
 	}
 	lockCLITestHooks(t)
 	prevPerform := performUpdate
@@ -634,6 +634,74 @@ func TestTeamsReleaseAutoUpdaterManagedRuntimeActivationUsesNormalRestart(t *tes
 	}
 	if res.ActivationPending {
 		t.Fatalf("managed runtime update reported ActivationPending: %s; RuntimeActivated updates must use the normal fresh-launch restart", res.ActivationReason)
+	}
+}
+
+func TestTeamsAutoUpdateActivationAfterApply(t *testing.T) {
+	tests := []struct {
+		name           string
+		prePending     bool
+		preReason      string
+		result         update.ApplyResult
+		wantPending    bool
+		wantReason     string
+		wantErrContain string
+	}{
+		{
+			name:        "legacy path mismatch remains pending",
+			prePending:  true,
+			preReason:   "running helper executable differs",
+			wantPending: true,
+			wantReason:  "running helper executable differs",
+		},
+		{
+			name:       "legacy stable path remains immediate",
+			preReason:  "",
+			wantReason: "",
+		},
+		{
+			name:       "managed runtime activation overrides physical path mismatch",
+			prePending: true,
+			preReason:  "running helper is the previous immutable runtime",
+			result: update.ApplyResult{
+				RuntimeActivated: true,
+			},
+		},
+		{
+			name:       "managed runtime rejects legacy restart requirement",
+			prePending: true,
+			result: update.ApplyResult{
+				RuntimeActivated: true,
+				RestartRequired:  true,
+			},
+			wantErrContain: "contradictory activation state",
+		},
+		{
+			name: "managed runtime rejects pending replacement",
+			result: update.ApplyResult{
+				RuntimeActivated:   true,
+				PendingReplacePath: "pending-helper",
+			},
+			wantErrContain: "contradictory activation state",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pending, reason, err := teamsAutoUpdateActivationAfterApply(tt.prePending, tt.preReason, tt.result)
+			if tt.wantErrContain != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrContain) {
+					t.Fatalf("error = %v, want containing %q", err, tt.wantErrContain)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("teamsAutoUpdateActivationAfterApply error: %v", err)
+			}
+			if pending != tt.wantPending || reason != tt.wantReason {
+				t.Fatalf("activation = pending %v reason %q, want pending %v reason %q", pending, reason, tt.wantPending, tt.wantReason)
+			}
+		})
 	}
 }
 

--- a/internal/cli/teams_auto_update_test.go
+++ b/internal/cli/teams_auto_update_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gofrs/flock"
 
+	"github.com/baaaaaaaka/codex-helper/internal/helperruntime"
 	"github.com/baaaaaaaka/codex-helper/internal/managedinstall"
 	"github.com/baaaaaaaka/codex-helper/internal/teams"
 	"github.com/baaaaaaaka/codex-helper/internal/update"
@@ -582,6 +583,57 @@ func TestTeamsReleaseAutoUpdaterApplyUsesRunningGoBinAndUnifiesManagedDefault(t 
 	}
 	if target, err := os.Readlink(managedCXP); err != nil || target != goBin {
 		t.Fatalf("managed cxp should be symlink to running helper, target=%q err=%v", target, err)
+	}
+}
+
+func TestTeamsReleaseAutoUpdaterManagedRuntimeActivationUsesNormalRestart(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the reported helper activation mismatch occurred on Linux/WSL")
+	}
+	lockCLITestHooks(t)
+	prevPerform := performUpdate
+	prevResolveInstallPath := teamsAutoUpdateResolveInstallPath
+	t.Cleanup(func() {
+		performUpdate = prevPerform
+		teamsAutoUpdateResolveInstallPath = prevResolveInstallPath
+	})
+
+	tmp := t.TempDir()
+	isolateTeamsUserDirsForTest(t, tmp)
+	entry := filepath.Join(tmp, ".local", "bin", "cxp")
+	runtimeRoot := filepath.Join(filepath.Dir(entry), ".cxp-runtime")
+	oldRuntime := helperruntime.VersionPath(runtimeRoot, "v1.2.3", runtime.GOOS)
+	targetRuntime := helperruntime.VersionPath(runtimeRoot, "v1.2.4", runtime.GOOS)
+	writeCLIFile(t, oldRuntime, upgradeCXPShimTestScript("1.2.3"), 0o755)
+	writeCLIFile(t, targetRuntime, upgradeCXPShimTestScript("1.2.4"), 0o755)
+	writeCLIFile(t, entry, upgradeCXPShimTestScript("1.2.4"), 0o755)
+
+	withTeamsServiceTestHooks(t, teamsServiceTestHooks{
+		goos:  "linux",
+		exe:   oldRuntime,
+		argv0: oldRuntime,
+		cwd:   tmp,
+	})
+	teamsAutoUpdateResolveInstallPath = func(string) (string, error) { return entry, nil }
+	performUpdate = func(_ context.Context, opts update.UpdateOptions) (update.ApplyResult, error) {
+		return update.ApplyResult{
+			Version:          "1.2.4",
+			InstallPath:      opts.InstallPath,
+			RuntimePath:      targetRuntime,
+			RuntimeActivated: true,
+		}, nil
+	}
+
+	updater := teamsReleaseAutoUpdater{repo: "owner/name"}
+	res, err := updater.Apply(context.Background(), teams.HelperAutoUpdateCandidate{
+		TagName: "v1.2.4",
+		Version: "1.2.4",
+	})
+	if err != nil {
+		t.Fatalf("Apply error: %v", err)
+	}
+	if res.ActivationPending {
+		t.Fatalf("managed runtime update reported ActivationPending: %s; RuntimeActivated updates must use the normal fresh-launch restart", res.ActivationReason)
 	}
 }
 

--- a/internal/cli/upgrade_cmd_test.go
+++ b/internal/cli/upgrade_cmd_test.go
@@ -3328,7 +3328,7 @@ func TestRestartTeamsHelperFromTeamsUsesPendingActivationForWindowsService(t *te
 	exitFunc = func(code int) {
 		exitCode = &code
 	}
-	startSelf = func(string, []string) error {
+	startSelf = func(string, []string, []string) error {
 		t.Fatal("pending Windows service restart must not start the old helper entry directly")
 		return nil
 	}
@@ -3396,7 +3396,7 @@ func TestRestartTeamsHelperFromTeamsUsesPendingProcessRestartForWindowsManualRun
 	exitFunc = func(code int) {
 		exitCode = &code
 	}
-	startSelf = func(string, []string) error {
+	startSelf = func(string, []string, []string) error {
 		t.Fatal("pending Windows manual restart must not start the old helper entry directly")
 		return nil
 	}

--- a/scripts/ci/cxp_process_identity_smoke.ps1
+++ b/scripts/ci/cxp_process_identity_smoke.ps1
@@ -14,6 +14,58 @@ foreach ($name in @("CXP_RUNTIME", "CXP_RUNTIME_ROOT", "CXP_RUNTIME_VERSION", "C
   Remove-Item ("Env:" + $name) -ErrorAction SilentlyContinue
 }
 
+function Assert-FreshLauncherDispatchesActiveRuntime {
+  $fixture = Join-Path $root "fresh-launch-restart"
+  $entry = Join-Path $fixture "cxp.exe"
+  $runtimeRoot = Join-Path $fixture ".cxp-runtime"
+  $oldVersion = "0.1.13-rc.9001"
+  $targetVersion = "0.1.13-rc.9002"
+  $oldRuntime = Join-Path $runtimeRoot "versions\v$oldVersion\cxp.exe"
+  $targetRuntime = Join-Path $runtimeRoot "versions\v$targetVersion\cxp.exe"
+
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $oldRuntime),(Split-Path -Parent $targetRuntime) | Out-Null
+  Push-Location $repoRoot
+  try {
+    & go build -trimpath `
+      -ldflags "-X github.com/baaaaaaaka/codex-helper/internal/cli.version=$oldVersion" `
+      -o $entry `
+      .\cmd\codex-proxy
+    Copy-Item -Force -LiteralPath $entry -Destination $oldRuntime
+    & go build -trimpath `
+      -ldflags "-X github.com/baaaaaaaka/codex-helper/internal/cli.version=$targetVersion" `
+      -o $targetRuntime `
+      .\cmd\codex-proxy
+  } finally {
+    Pop-Location
+  }
+  Set-Content -LiteralPath (Join-Path $runtimeRoot "active") -NoNewline -Value "v$targetVersion"
+
+  try {
+    $env:CXP_RUNTIME = "1"
+    $env:CXP_RUNTIME_ROOT = $runtimeRoot
+    $env:CXP_RUNTIME_VERSION = "v$oldVersion"
+    $env:CXP_ENTRY_PATH = $entry
+    $staleOutput = (& $entry --version | Out-String)
+    $staleOutput | Write-Host
+    if ($staleOutput -notmatch [regex]::Escape($oldVersion)) {
+      throw "runtime-marked launcher did not stay pinned to $oldVersion`: $staleOutput"
+    }
+  } finally {
+    foreach ($name in @("CXP_RUNTIME", "CXP_RUNTIME_ROOT", "CXP_RUNTIME_VERSION", "CXP_ENTRY_PATH", "CXP_RUNTIME_DISABLE", "CXP_RUNTIME_FORCE")) {
+      Remove-Item ("Env:" + $name) -ErrorAction SilentlyContinue
+    }
+  }
+
+  $freshOutput = (& $entry --version | Out-String)
+  $freshOutput | Write-Host
+  if ($freshOutput -notmatch [regex]::Escape($targetVersion)) {
+    throw "fresh stable launcher did not dispatch active runtime $targetVersion`: $freshOutput"
+  }
+  if ((Get-Content -Raw (Join-Path $runtimeRoot "active")).Trim() -ne "v$targetVersion") {
+    throw "fresh stable launcher changed the active runtime pointer"
+  }
+}
+
 try {
   New-Item -ItemType Directory -Force -Path $root | Out-Null
   Push-Location $repoRoot
@@ -22,6 +74,8 @@ try {
   } finally {
     Pop-Location
   }
+
+  Assert-FreshLauncherDispatchesActiveRuntime
 
   $stdout = Join-Path $root "stdout.log"
   $stderr = Join-Path $root "stderr.log"

--- a/scripts/ci/cxp_process_identity_smoke.ps1
+++ b/scripts/ci/cxp_process_identity_smoke.ps1
@@ -18,8 +18,8 @@ function Assert-FreshLauncherDispatchesActiveRuntime {
   $fixture = Join-Path $root "fresh-launch-restart"
   $entry = Join-Path $fixture "cxp.exe"
   $runtimeRoot = Join-Path $fixture ".cxp-runtime"
-  $oldVersion = "0.1.13-rc.9001"
-  $targetVersion = "0.1.13-rc.9002"
+  $oldVersion = "0.1.13-rc.56"
+  $targetVersion = "0.1.13-rc.57"
   $oldRuntime = Join-Path $runtimeRoot "versions\v$oldVersion\cxp.exe"
   $targetRuntime = Join-Path $runtimeRoot "versions\v$targetVersion\cxp.exe"
 

--- a/scripts/ci/cxp_process_identity_smoke.sh
+++ b/scripts/ci/cxp_process_identity_smoke.sh
@@ -45,6 +45,63 @@ assert_process_clean() {
   fi
 }
 
+assert_fresh_launcher_dispatches_active_runtime() {
+  local fixture="$root/fresh-launch-restart"
+  local entry="$fixture/cxp"
+  local runtime_root="$fixture/.cxp-runtime"
+  local old_version="0.1.13-rc.9001"
+  local target_version="0.1.13-rc.9002"
+  local old_runtime="$runtime_root/versions/v$old_version/cxp"
+  local target_runtime="$runtime_root/versions/v$target_version/cxp"
+
+  mkdir -p "$(dirname "$old_runtime")" "$(dirname "$target_runtime")"
+  (
+    cd "$repo_root"
+    go build -trimpath \
+      -ldflags "-X github.com/baaaaaaaka/codex-helper/internal/cli.version=$old_version" \
+      -o "$entry" \
+      ./cmd/codex-proxy
+    install -m 0755 "$entry" "$old_runtime"
+    go build -trimpath \
+      -ldflags "-X github.com/baaaaaaaka/codex-helper/internal/cli.version=$target_version" \
+      -o "$target_runtime" \
+      ./cmd/codex-proxy
+  )
+  printf 'v%s\n' "$target_version" >"$runtime_root/active"
+
+  local stale_output
+  stale_output="$(
+    CXP_RUNTIME=1 \
+      CXP_RUNTIME_ROOT="$runtime_root" \
+      CXP_RUNTIME_VERSION="v$old_version" \
+      CXP_ENTRY_PATH="$entry" \
+      "$entry" --version
+  )"
+  printf '%s\n' "$stale_output"
+  if [[ "$stale_output" != *"$old_version"* ]]; then
+    echo "runtime-marked launcher did not stay pinned to $old_version" >&2
+    exit 1
+  fi
+
+  local fresh_output
+  fresh_output="$(
+    env \
+      -u CXP_RUNTIME \
+      -u CXP_RUNTIME_ROOT \
+      -u CXP_RUNTIME_VERSION \
+      -u CXP_ENTRY_PATH \
+      -u CXP_RUNTIME_DISABLE \
+      -u CXP_RUNTIME_FORCE \
+      "$entry" --version
+  )"
+  printf '%s\n' "$fresh_output"
+  if [[ "$fresh_output" != *"$target_version"* ]]; then
+    echo "fresh stable launcher did not dispatch active runtime $target_version" >&2
+    exit 1
+  fi
+  test "$(tr -d '\r\n' <"$runtime_root/active")" = "v$target_version"
+}
+
 wait_for_runtime() {
   local current_pid="$1"
   local active="$root/.cxp-runtime/active"
@@ -79,6 +136,8 @@ cd "$repo_root"
 go build -o "$root/cxp" ./cmd/codex-proxy
 cp "$root/cxp" "$root/codex-proxy"
 chmod 0755 "$root/cxp" "$root/codex-proxy"
+
+assert_fresh_launcher_dispatches_active_runtime
 
 for entry in cxp codex-proxy; do
   : >"$root/stdout.log"

--- a/scripts/ci/cxp_process_identity_smoke.sh
+++ b/scripts/ci/cxp_process_identity_smoke.sh
@@ -49,8 +49,8 @@ assert_fresh_launcher_dispatches_active_runtime() {
   local fixture="$root/fresh-launch-restart"
   local entry="$fixture/cxp"
   local runtime_root="$fixture/.cxp-runtime"
-  local old_version="0.1.13-rc.9001"
-  local target_version="0.1.13-rc.9002"
+  local old_version="0.1.13-rc.56"
+  local target_version="0.1.13-rc.57"
   local old_runtime="$runtime_root/versions/v$old_version/cxp"
   local target_runtime="$runtime_root/versions/v$target_version/cxp"
 


### PR DESCRIPTION
This PR first adds a RED GitHub CI reproduction for the Teams managed-runtime activation mismatch, then fixes it. RuntimeActivated now overrides the pre-update physical-path mismatch only when the update result is internally consistent; legacy and pending-replacement paths remain unchanged. Stable-entry restarts remove launch-only runtime markers, and Windows restart processes now receive the explicit environment. The focused activation/restart contract runs on Linux, macOS, and Windows. Local validation: go test ./..., focused race test, go vet ./..., Windows amd64 and macOS arm64 test cross-compiles, and actionlint.